### PR TITLE
Add DEFCON control monitor program

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,19 @@ The repository includes a separate `password` program that controls a redstone d
 ## Logs
 Logs are written to `data/logs/launch_log.txt` whenever significant events occur (if the directory exists). You can view these logs from within the command center by choosing the appropriate menu option in some versions of the program.
 
+## DEFCON Level Demo
+`services/defcon_control.lua` presents a simple interface for experimenting with
+different DEFCON levels. The program automatically searches for an attached
+monitor and displays buttons labeled **1** through **5**. Selecting a button
+lowers or raises the current level—descending requires going one step at a time
+while ascending can skip levels. Each level changes the monitor's color and
+selecting level **1** causes the screen to blink briefly before remaining red
+until another level is chosen.
+
+Run it with:
+
+```
+services/defcon_control.lua
+```
+
 For additional technical details see `docs/README.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,6 @@ This is a fictional command system for use with CC:Tweaked in Minecraft.
 
 * `services/command_center.lua` - main interface
 * `services/remote_listener.lua` - run on remote computers to accept commands
+* `services/defcon_control.lua` - interactive DEFCON level display on a monitor
 
 Configuration files can be found in `config/`.

--- a/services/defcon_control.lua
+++ b/services/defcon_control.lua
@@ -1,0 +1,99 @@
+-- services/defcon_control.lua
+-- Interactive DEFCON level controller for a ComputerCraft monitor
+
+local levelColors = {
+    [1] = colors.red,
+    [2] = colors.orange,
+    [3] = colors.yellow,
+    [4] = colors.green,
+    [5] = colors.blue,
+}
+
+local currentLevel = 5
+local monitor
+
+local function findMonitor()
+    while not monitor do
+        for _, name in ipairs(peripheral.getNames()) do
+            if peripheral.getType(name) == "monitor" then
+                monitor = peripheral.wrap(name)
+                monitor.setTextScale(1)
+                break
+            end
+        end
+        if not monitor then
+            term.clear()
+            print("Waiting for monitor...")
+            sleep(2)
+        end
+    end
+end
+
+local function headerText()
+    return string.format("DEFCON %d", currentLevel)
+end
+
+local function drawButtons()
+    local y = 3
+    for i = 1, 5 do
+        monitor.setBackgroundColor(levelColors[i])
+        monitor.setTextColor(colors.black)
+        monitor.setCursorPos(2, y)
+        monitor.write(" " .. i .. " ")
+        y = y + 2
+    end
+end
+
+local function drawScreen()
+    local w, _ = monitor.getSize()
+    monitor.setBackgroundColor(levelColors[currentLevel])
+    monitor.clear()
+    monitor.setTextColor(colors.white)
+    local text = headerText()
+    monitor.setCursorPos(math.floor((w - #text) / 2) + 1, 1)
+    monitor.write(text)
+    drawButtons()
+    monitor.setBackgroundColor(levelColors[currentLevel])
+end
+
+local function blinkDefcon1()
+    for i = 1, 4 do
+        drawScreen()
+        sleep(0.5)
+        monitor.setBackgroundColor(colors.black)
+        monitor.clear()
+        sleep(0.5)
+    end
+    drawScreen()
+end
+
+local function handleTouch(x, y)
+    local posY = 3
+    for i = 1, 5 do
+        if y == posY and x >= 2 and x <= 4 then
+            if i == currentLevel then
+                return
+            end
+            if i < currentLevel and i ~= currentLevel - 1 then
+                return
+            end
+            currentLevel = i
+            if currentLevel == 1 then
+                blinkDefcon1()
+            else
+                drawScreen()
+            end
+            return
+        end
+        posY = posY + 2
+    end
+end
+
+findMonitor()
+drawScreen()
+
+while true do
+    local _, _, x, y = os.pullEvent("monitor_touch")
+    handleTouch(x, y)
+end
+


### PR DESCRIPTION
## Summary
- add new `defcon_control.lua` service that displays DEFCON levels on a monitor
- document the new tool in README and docs/README

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889627b8d808320a09a4f5ea88414ce